### PR TITLE
Fix a typo in system config

### DIFF
--- a/src/app/code/community/Bitbull/Soisy/etc/system.xml
+++ b/src/app/code/community/Bitbull/Soisy/etc/system.xml
@@ -171,7 +171,7 @@
                         </checkout_loan_quote_placement>
 
                         <loan_quote_text_checkout>
-                            <label>Text for cart page loan quote block</label>
+                            <label>Text for checkout page loan quote block</label>
                             <frontend_type>textarea</frontend_type>
                             <sort_order>60</sort_order>
                             <show_in_default>1</show_in_default>


### PR DESCRIPTION
Replace "cart" with "checkout" in loan_quote_text_checkout field's label